### PR TITLE
Feature/det

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -118,6 +118,51 @@ impl<T: Num> Matrix<T> {
         }
         Matrix::from_vec(v)
     }
+
+    fn cofactor(&self, i: usize, j: usize) -> T {
+        let (m,n) = self.shape();
+
+        assert!(
+            self.is_square(),
+            "cofactor is only defined for square metrices"
+        );
+        assert!(
+            m > 1,
+            "cofactor is not defined for (1,1) matrices"
+        );
+        assert!(
+            i <= m && j <= n,
+            "index out of range"
+        );
+
+        if (i+j) % 2 == 0 {
+            self.submat(i, j).det()
+        } else {
+            - self.submat(i, j).det()
+        }
+    }
+
+    pub fn cofactor_mat(&self) -> Self {
+        let mut v = Vec::new();
+        let (m, n) = self.shape();
+
+        assert!(
+            self.is_square(),
+            "cofactor matrix is only defined for square metrices"
+        );
+        assert!(
+            m > 1,
+            "cofactor matrix is not defined for (1,1) matrices"
+        );
+
+        for i in 1..=n {
+            v.push(Vec::new());
+            for j in 1..=m {
+                v.last_mut().unwrap().push(self.cofactor(j, i));
+            }
+        }
+        Matrix::from_vec(v)
+    }
 }
 
 impl<T: Num> std::fmt::Display for Matrix<T> {
@@ -772,6 +817,93 @@ mod tests {
                 m.det(),
                 -7
             )
+        }
+    }
+
+    mod cofactor {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "cofactor is only defined for square metrices")]
+        fn non_square_panic() {
+            let m = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6]
+            ]);
+            m.cofactor(1,2);
+        }
+
+        #[test]
+        #[should_panic(expected = "cofactor is not defined for (1,1) matrices")]
+        fn one_one_matrix_panic() {
+            let m = Matrix::from_vec(vec![vec![2]]);
+            m.cofactor(1,1);
+        }
+
+        #[test]
+        #[should_panic(expected = "index out of range")]
+        fn index_out_of_range_panic() {
+            let m = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6],
+                vec![7,8,9]
+            ]);
+            m.cofactor(4,1);
+        }
+
+        #[test]
+        fn calc() {
+            let m = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6],
+                vec![7,8,9]
+            ]);
+            assert_eq!(
+                m.cofactor(1,1),
+                -3
+            );
+            assert_eq!(
+                m.cofactor(2,3),
+                6
+            );
+        }
+    }
+
+    mod cofactor_mat {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "cofactor matrix is only defined for square metrices")]
+        fn non_square_panic() {
+            let m = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6]
+            ]);
+            m.cofactor_mat();
+        }
+
+        #[test]
+        #[should_panic(expected = "cofactor matrix is not defined for (1,1) matrices")]
+        fn one_one_matrix_panic() {
+            let m = Matrix::from_vec(vec![vec![2]]);
+            m.cofactor_mat();
+        }
+
+        #[test]
+        fn calc() {
+            let m = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6],
+                vec![7,8,9]
+            ]);
+            assert_eq!(
+                m.cofactor_mat(),
+                Matrix::from_vec(vec![
+                    vec![-3, 6, -3],
+                    vec![6, -12, 6],
+                    vec![-3, 6, -3]
+                ])
+            );
         }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -163,6 +163,16 @@ impl<T: Num> Matrix<T> {
         }
         Matrix::from_vec(v)
     }
+
+    pub fn is_regular(&self) -> bool {
+        let (m, n) = self.shape();
+        assert_eq!(
+            m, n,
+            "the regularity is only defined for square matrices"
+        );
+
+        self.det() != T::zero()
+    }
 }
 
 impl<T: Num> std::fmt::Display for Matrix<T> {
@@ -495,11 +505,11 @@ mod tests {
 
         #[test]
         #[should_panic(expected = "only square matrices can be powered")]
-        fn non_square_matrix_panic() {
-            let non_square_mat = Matrix::from_vec(vec![
+        fn non_square_panic() {
+            let non_square = Matrix::from_vec(vec![
                 vec![1, 2]
             ]);
-            non_square_mat.pow(3);
+            non_square.pow(3);
         }
 
         #[test]
@@ -826,11 +836,11 @@ mod tests {
         #[test]
         #[should_panic(expected = "cofactor is only defined for square metrices")]
         fn non_square_panic() {
-            let m = Matrix::from_vec(vec![
+            let non_square = Matrix::from_vec(vec![
                 vec![1,2,3],
                 vec![4,5,6]
             ]);
-            m.cofactor(1,2);
+            non_square.cofactor(1,2);
         }
 
         #[test]
@@ -873,17 +883,17 @@ mod tests {
         use super::*;
 
         #[test]
-        #[should_panic(expected = "cofactor matrix is only defined for square metrices")]
+        #[should_panic(expected = "the cofactor matrix is only defined for square metrices")]
         fn non_square_panic() {
-            let m = Matrix::from_vec(vec![
+            let non_square = Matrix::from_vec(vec![
                 vec![1,2,3],
                 vec![4,5,6]
             ]);
-            m.cofactor_mat();
+            non_square.cofactor_mat();
         }
 
         #[test]
-        #[should_panic(expected = "cofactor matrix is not defined for (1,1) matrices")]
+        #[should_panic(expected = "the cofactor matrix is not defined for (1,1) matrices")]
         fn one_one_matrix_panic() {
             let m = Matrix::from_vec(vec![vec![2]]);
             m.cofactor_mat();
@@ -904,6 +914,40 @@ mod tests {
                     vec![-3, 6, -3]
                 ])
             );
+        }
+    }
+
+    mod is_regular {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "the regularity is only defined for square matrices")]
+        fn non_square_panic() {
+            let non_square = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6]
+            ]);
+            non_square.is_regular();
+        }
+
+        #[test]
+        fn regular_return_true() {
+            let regular = Matrix::from_vec(vec![
+                vec![1, 2, 1],
+                vec![2, 1, 1],
+                vec![1, 1, 2]
+            ]);
+            assert!( regular.is_regular() );
+        }
+
+        #[test]
+        fn irregular_return_false() {
+            let irregular = Matrix::from_vec(vec![
+                vec![1, 2, 1],
+                vec![2, 1, 1],
+                vec![3, 3, 2]
+            ]);
+            assert!( ! irregular.is_regular() );
         }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -75,6 +75,49 @@ impl<T: Num> Matrix<T> {
             x => &(self * self).pow(x / 2) * self
         }
     }
+
+    pub fn det(&self) -> T {
+        assert!(
+            self.is_square(),
+            "det is only defined for square matrices"
+        );
+
+        if self.shape().0 == 1 {
+            return self.elem[0][0];
+        } else {
+            self.elem[0].iter().enumerate().map(|(j, &a1j)| {
+                let j = j+1;
+                if (1+j) % 2 == 0 {
+                    a1j * self.submat(1,j).det()
+                } else {
+                    - a1j * self.submat(1,j).det()
+                }
+            }).sum()
+        }
+    }
+
+    fn submat(&self, i: usize, j: usize) -> Self {
+        let (m, n) = self.shape();
+        assert!(m > 1 && n > 1);
+
+        let i = i-1;
+        let j = j-1;
+
+        let mut v = Vec::new();
+        for s in 0..m {
+            if s == i {
+                continue;
+            }
+            v.push(Vec::new());
+            for t in 0..n {
+                if t == j {
+                    continue;
+                }
+                v.last_mut().unwrap().push(self.elem[s][t]);
+            }
+        }
+        Matrix::from_vec(v)
+    }
 }
 
 impl<T: Num> std::fmt::Display for Matrix<T> {
@@ -682,5 +725,53 @@ mod tests {
                 vec![Complex::new(2,3), Complex::new(0,-3), Complex::new(2,-1)]
             ])
         )
+    }
+
+    mod det {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "det is only defined for square matrices")]
+        fn non_square_panic() {
+            let non_square = Matrix::from_vec(vec![
+                vec![1, 2, 3],
+                vec![4, 5, 6]
+            ]);
+            non_square.det();
+        }
+
+        #[test]
+        fn one() {
+            let m = Matrix::from_vec(vec![vec![2]]);
+            assert_eq!(
+                m.det(),
+                2
+            );
+        }
+
+        #[test]
+        fn two() {
+            let m = Matrix::from_vec(vec![
+                vec![1, 2],
+                vec![3, 4]
+            ]);
+            assert_eq!(
+                m.det(),
+                1 * 4 - 2 * 3
+            )
+        }
+
+        #[test]
+        fn three() {
+            let m = Matrix::from_vec(vec![
+                vec![2, 1, 0],
+                vec![3, 1, 2],
+                vec![-1, 0, 5]
+            ]);
+            assert_eq!(
+                m.det(),
+                -7
+            )
+        }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -148,11 +148,11 @@ impl<T: Num> Matrix<T> {
 
         assert!(
             self.is_square(),
-            "cofactor matrix is only defined for square metrices"
+            "the cofactor matrix is only defined for square metrices"
         );
         assert!(
             m > 1,
-            "cofactor matrix is not defined for (1,1) matrices"
+            "the cofactor matrix is not defined for (1,1) matrices"
         );
 
         for i in 1..=n {
@@ -174,6 +174,17 @@ impl<T: ExactNum> Matrix<T> {
         );
 
         self.det() != T::zero()
+    }
+
+    // panics if the matrix is not square
+    // returns None if the matrix is not regular
+    pub fn inverse(&self) -> Option<Matrix<T::DivOutput>> {
+        if self.is_regular() {
+            let d = self.det();
+            Some( map_elem(|x| ExactNum::div(x, d), &self.cofactor_mat()) )
+        } else {
+            None
+        }
     }
 }
 
@@ -968,6 +979,49 @@ mod tests {
                 vec![Complex::new(-2, -4), Complex::new(0, -6)]
             ]);
             assert!( ! irregular.is_regular() );
+        }
+    }
+
+    mod inverse {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "the regularity is only defined for square matrices")]
+        fn non_square_panic() {
+            let non_square = Matrix::from_vec(vec![
+                vec![1,2,3],
+                vec![4,5,6]
+            ]);
+            non_square.inverse();
+        }
+
+        #[test]
+        fn regular_return_inverse_matrix() {
+            let regular = Matrix::from_vec(vec![
+                vec![1, 2],
+                vec![3, 1],
+            ]);
+            assert_eq!(
+                regular.inverse(),
+                Some(
+                    Matrix::from_vec(vec![
+                        vec![Rational::new(-1,5), Rational::new(2,5)],
+                        vec![Rational::new(3,5), Rational::new(-1,5)],
+                    ])
+                )
+            );
+        }
+
+        #[test]
+        fn irregular_return_none() {
+            let irregular = Matrix::from_vec(vec![
+                vec![1, 2],
+                vec![1, 2]
+            ]);
+            assert_eq!(
+                irregular.inverse(),
+                None
+            );
         }
     }
 }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -163,7 +163,9 @@ impl<T: Num> Matrix<T> {
         }
         Matrix::from_vec(v)
     }
+}
 
+impl<T: ExactNum> Matrix<T> {
     pub fn is_regular(&self) -> bool {
         let (m, n) = self.shape();
         assert_eq!(
@@ -946,6 +948,24 @@ mod tests {
                 vec![1, 2, 1],
                 vec![2, 1, 1],
                 vec![3, 3, 2]
+            ]);
+            assert!( ! irregular.is_regular() );
+        }
+
+        #[test]
+        fn works_for_rational() {
+            let irregular = Matrix::from_vec(vec![
+                vec![Rational::new(15,1), Rational::new(25,1)],
+                vec![Rational::new(3,1000), Rational::new(5,1000)]
+            ]);
+            assert!( ! irregular.is_regular() );
+        }
+
+        #[test]
+        fn works_for_complex() {
+            let irregular = Matrix::from_vec(vec![
+                vec![Complex::new(1,2), Complex::new(0, 3)],
+                vec![Complex::new(-2, -4), Complex::new(0, -6)]
             ]);
             assert!( ! irregular.is_regular() );
         }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -179,6 +179,12 @@ impl<T: ExactNum> Matrix<T> {
     // panics if the matrix is not square
     // returns None if the matrix is not regular
     pub fn inverse(&self) -> Option<Matrix<T::DivOutput>> {
+        let (m, n) = self.shape();
+        assert_eq!(
+            m, n,
+            "the inverse matrix is only defined for square matrices"
+        );
+
         if self.is_regular() {
             let d = self.det();
             Some( map_elem(|x| ExactNum::div(x, d), &self.cofactor_mat()) )
@@ -986,7 +992,7 @@ mod tests {
         use super::*;
 
         #[test]
-        #[should_panic(expected = "the regularity is only defined for square matrices")]
+        #[should_panic(expected = "the inverse matrix is only defined for square matrices")]
         fn non_square_panic() {
             let non_square = Matrix::from_vec(vec![
                 vec![1,2,3],

--- a/src/num.rs
+++ b/src/num.rs
@@ -15,16 +15,17 @@ pub trait Num : Clone + Copy + Debug + Display + PartialEq + Neg<Output = Self> 
 
 pub trait RealNum: Clone + Copy + Debug + Display + PartialEq + Neg<Output = Self> + Add<Self, Output = Self> + Zero + Sub<Self, Output = Self> + Mul<Self, Output = Self> + One + Sum {}
 
-impl RealNum for i32 {}
+impl<T: Integer> RealNum for T {}
 impl RealNum for f32 {}
 
 impl<T: RealNum> Num for T {}
 
-pub trait ExactNum: Num {}
+// an implementor type can be used to do calculations (including division) without arithmetic error.
+pub trait ExactNum: Num {
+    type DivOutput: Num;
 
-impl<T: Integer> ExactNum for T {}
-impl<T: Integer> ExactNum for Rational<T> {}
-impl<T: ExactNum> ExactNum for Complex<T> {}
+    fn div(self, rhs: Self) -> Self::DivOutput;
+}
 
 
 pub trait Zero {

--- a/src/num.rs
+++ b/src/num.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::iter::Sum;
 pub use complex::Complex;
-pub use rational::Rational;
+pub use rational::*;
 
 
 pub trait Num : Clone + Copy + Debug + Display + PartialEq + Neg<Output = Self> + Add<Self, Output = Self> + Zero + Sub<Self, Output = Self> + Mul<Self, Output = Self> + One + Sum {
@@ -19,6 +19,12 @@ impl RealNum for i32 {}
 impl RealNum for f32 {}
 
 impl<T: RealNum> Num for T {}
+
+pub trait ExactNum: Num {}
+
+impl<T: Integer> ExactNum for T {}
+impl<T: Integer> ExactNum for Rational<T> {}
+impl<T: ExactNum> ExactNum for Complex<T> {}
 
 
 pub trait Zero {

--- a/src/num/complex.rs
+++ b/src/num/complex.rs
@@ -110,6 +110,27 @@ impl<T: Num> Sum for Complex<T> {
 
 impl<T: Num> Num for Complex<T> {}
 
+impl<T> ExactNum for Complex<T>
+where
+    T: RealNum + ExactNum,
+    T::DivOutput: RealNum
+{
+    type DivOutput = Complex<T::DivOutput>;
+
+    fn div(self, rhs: Self) -> Self::DivOutput {
+        assert_ne!(
+            rhs, Self::zero(),
+            "cannot divide by 0"
+        );
+
+        let denom = (rhs * rhs.c()).re();
+        let nom = self * rhs.c();
+        let re = nom.re().div(denom);
+        let im = nom.im().div(denom);
+        Self::DivOutput::new(re, im)
+    }
+}
+
 
 
 #[cfg(test)]

--- a/src/num/complex.rs
+++ b/src/num/complex.rs
@@ -108,7 +108,7 @@ impl<T: Num> Sum for Complex<T> {
     }
 }
 
-impl<T: RealNum> Num for Complex<T> {}
+impl<T: Num> Num for Complex<T> {}
 
 
 


### PR DESCRIPTION
add fn det, cofactor, cofactor_mat, is_regular and inverse.
add trait ExactNum to restrict the use of is_regular() and inverse() to types that does not cause arithmetic error.
ExactNum has div(). Unlike std implementation of Div for i32, this function returns Rational as a result of integer division.